### PR TITLE
Show parse errors during test runs

### DIFF
--- a/src/main/scala/viper/silver/testing/SilSuite.scala
+++ b/src/main/scala/viper/silver/testing/SilSuite.scala
@@ -121,6 +121,7 @@ abstract class SilSuite extends AnnotationBasedTestSuite with BeforeAndAfterAllC
             // this case cancels any parsing errors, leaving only verification one
             // can remove w/o causing problems
             case p: ParseError =>
+              info(p.readableMessage)
               cancel
             case rest: AbstractError =>
               rest


### PR DESCRIPTION
A simple one-line change to help debug parse errors.